### PR TITLE
add regex validation feature

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -94,6 +94,30 @@
       </div>
       <div class="row mb-3 g-3">
         <div class="col-md-4">
+          <label for="validationTagsNew" class="form-label">Tags (allow new and check with regex if its a external mail address)</label>
+          <select class="form-select" id="validationTagsNew" name="tags_new[]" multiple data-allow-new="true" data-regex=".*@mycompany\.com$">
+            <option disabled hidden value="">Add mail address</option>
+            <option value="1" selected="selected">info@mycompany.com</option>
+            <option value="2">mr.x@mycompany.com</option>
+            <option value="3">ms.x@mycompany.com</option>
+          </select>
+          <div class="invalid-feedback">Please select a e-mail.</div>
+        </div>
+      </div>
+      <div class="row mb-3 g-3">
+        <div class="col-md-4">
+          <label for="validationTagsNew" class="form-label">Tags (allow new only if it matches regex)</label>
+          <select class="form-select" id="validationTagsNew" name="tags_new[]" multiple data-allow-new="true" data-regex=".*@mycompany\.com$" data-validate-new="true">
+            <option disabled hidden value="">Add mail address</option>
+            <option value="1" selected="selected">info@mycompany.com</option>
+            <option value="2">mr.x@mycompany.com</option>
+            <option value="3">ms.x@mycompany.com</option>
+          </select>
+          <div class="invalid-feedback">Please select only @mycompany.com addresses.</div>
+        </div>
+      </div>
+      <div class="row mb-3 g-3">
+        <div class="col-md-4">
           <label for="validationTagsJson" class="form-label">Tags (server side)</label>
           <select class="form-select" id="validationTagsJson" name="tags_json[]" multiple data-allow-new="true" data-server="demo.json" data-live-server="1">
             <option disabled hidden value="">Choose a tag...</option>

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,18 @@ Use attribute `data-suggestions-threshold` to determine how many characters need
 <select class="form-select" id="validationTags" name="tags[]" multiple data-suggestions-threshold="0">
 ```
 
+Use attribute `data-validate-regex` to do a regex validation. Not matching tags are getting a warning color. This color can be defined with `data-warning-badge-style`.
+
+```html
+<select class="form-select" id="validationTags" name="tags[]" multiple data-validate-regex=".*@mycompany\.com$" data-warning-badge-style="warning">
+```
+
+Use attribute `data-validate-new` together with `data-validate-regex` to only allow new tags, when they match the given regex. Not matching tags cannot be added and it shows the invalid feedback. 
+
+```html
+<select class="form-select" id="validationTags" name="tags[]" multiple data-validate-new="true" data-validate-regex=".*@mycompany\.com$">
+```
+
 *NOTE: don't forget the [] if you need multiple values!*
 
 ## Server side support

--- a/tags.js
+++ b/tags.js
@@ -25,12 +25,15 @@ class Tags {
     this.selectElement.style.display = "none";
     this.placeholder = this.getPlaceholder();
     this.allowNew = selectElement.dataset.allowNew ? true : false;
+    this.validateNew = selectElement.dataset.validateNew ? true : false;
     this.showAllSuggestions = selectElement.dataset.showAllSuggestions ? true : false;
     this.badgeStyle = selectElement.dataset.badgeStyle || "primary";
+    this.warningBadgeStyle = selectElement.dataset.warningBadgeStyle || "warning";
     this.allowClear = selectElement.dataset.allowClear ? true : false;
     this.server = selectElement.dataset.server || false;
     this.liveServer = selectElement.dataset.liveServer ? true : false;
     this.suggestionsThreshold = selectElement.dataset.suggestionsThreshold ? parseInt(selectElement.dataset.suggestionsThreshold) : 1;
+    this.validationRegex = selectElement.dataset.regex || "";
     this.keyboardNavigation = false;
     this.clearLabel = opts.clearLabel || "Clear";
     this.searchLabel = opts.searchLabel || "Type a value";
@@ -468,6 +471,10 @@ class Tags {
       // No item and we don't allow new items => error
       if (!this.allowNew && !(search.length === 0 && !hasPossibleValues)) {
         this.holderElement.classList.add("is-invalid");
+        } else if (this.allowNew && this.validateNew && !this.validateRegex(search)) {
+            this.holderElement.classList.add("is-invalid");
+        } else if (this.allowNew && this.validateRegex(search) && this.holderElement.classList.contains("is-invalid")) {
+            this.holderElement.classList.remove("is-invalid");
       }
     }
   }
@@ -480,7 +487,7 @@ class Tags {
       this.dropElement.classList.remove("show");
     }
     if (this.holderElement.classList.contains("is-invalid")) {
-      this.holderElement.classList.remove("is-invalid");
+        this.holderElement.classList.remove("is-invalid");
     }
   }
 
@@ -540,6 +547,16 @@ class Tags {
   }
 
   /**
+   * Checks if value matches a configured regex
+   * @param {string} value
+   * @returns {boolean}
+   */
+  validateRegex(value){
+    const regex = new RegExp(this.validationRegex.trim());
+    return regex.test(value);
+  }
+
+  /**
    * @param {string} text
    * @param {string} value
    * @param {object} data
@@ -563,6 +580,9 @@ class Tags {
     span.classList.add("badge");
     if (data.badgeStyle) {
       badgeStyle = data.badgeStyle;
+    }
+    if(!this.validateRegex(text)){
+      badgeStyle = this.warningBadgeStyle;
     }
     if (data.badgeClass) {
       span.classList.add(data.badgeClass);


### PR DESCRIPTION
This pull request adds regex validation capabilities to the tags.
You can configure it server-side with adding the regarding data elements to the select tag. 

You can say `data-validate-regex="myregex"` to add a warning color to every tag that does not match the given regex. This is only useful with the `allowNew` option. 
You can further add `data-validate-new="true` to only allow matching tags with the new option. 

I needed this for my project and you can merge it if its helpful. The feature is tested, and I added the necessary parts in  readme.md and demo.html

You still have to update the minified js file. 