### PR TITLE
Add support for readonly-tags

### DIFF
--- a/demo-standalone.html
+++ b/demo-standalone.html
@@ -28,6 +28,9 @@
     .container {
       padding: 2em
     }
+    .badge.disabled {
+      opacity: 0.5;
+    }
   </style>
 </head>
 
@@ -55,6 +58,19 @@
             <option value="1" selected="selected">Apple</option>
             <option value="2">Banana</option>
             <option value="3">Orange</option>
+          </select>
+          <div class="invalid-feedback">Please select a valid tag.</div>
+        </div>
+      </div>
+      <div class="row mb-3 g-3">
+        <div class="col-md-4">
+          <label for="validationTagsClearReadonly" class="form-label">Tags (allow clear + readonly / disabled tags)</label>
+          <select class="form-select" id="validationTagsClearReadonly" name="tagsClearReadonly[]" multiple data-allow-clear="true">
+            <option disabled hidden value="">Choose a tag...</option>
+            <option value="1" selected="selected">Apple</option>
+            <option value="2" selected="selected" data-readonly="readonly">Banana</option>
+            <option value="3">Orange</option>
+            <option value="4" selected="selected" disabled>Blueberry</option>
           </select>
           <div class="invalid-feedback">Please select a valid tag.</div>
         </div>

--- a/tags.js
+++ b/tags.js
@@ -511,7 +511,6 @@ class Tags {
       if (initialValue.hasAttribute("disabled")) {
         initialValue.dataset.disabled = "true";
       }
-
       this._createBadge(initialValue.textContent, initialValue.value, initialValue.dataset);
     }
   }
@@ -1318,7 +1317,7 @@ class Tags {
    * @param {boolean} noEvents
    */
   removeLastItem(noEvents = false) {
-    let items = this._containerElement.querySelectorAll("span:not(.disabled)");
+    let items = this._containerElement.querySelectorAll("span:not(.disabled):not(.data-read-only)");
     if (!items.length) {
       return;
     }
@@ -1471,12 +1470,15 @@ class Tags {
    */
   _createBadge(text, value = null, data = {}) {
     const bver = this._getBootstrapVersion();
-    const allowClear = this._config.allowClear && !data.disabled;
+    const allowClear = this._config.allowClear && !data.disabled && !data.readonly;
 
     // create span
     let html = text;
     let span = document.createElement("span");
     let classes = ["badge"];
+    if (data.readonly) {
+      classes.push("data-read-only")
+    }
     let badgeStyle = this._config.badgeStyle;
     if (data.badgeStyle) {
       badgeStyle = data.badgeStyle;


### PR DESCRIPTION
Hi,
As suggested I created draft for read-only tags.
Issues that I believer deserve mentioning:
If You try to remove readonly tag by backspace, nothing will happen, even if You have tags earlier, that could be removed.
If next tag for removal by backspace is "readonly" tag, then the feature is disabled. Tags before "readonly" one, can still be removed by taping on the "x" button.

I merged my repo with newest master, to add support for disabled tags as well. I noticed it too late.