### PR TITLE
#89 placeholder respect autofirst option

### DIFF
--- a/tags.js
+++ b/tags.js
@@ -485,7 +485,7 @@ class Tags {
     }
     // Fallback to first option if no value
     let firstOption = this._selectElement.querySelector("option");
-    if (!firstOption) {
+    if (!firstOption || !this._config.autoselectFirst) {
       return "";
     }
     if (firstOption.hasAttribute("selected")) {


### PR DESCRIPTION
> ref #89 

This PR will fix this behavior : 

> If we juste set default selected options without placeholder, the lib will automatically deselect every options and keep first selected (option autoselectFirst is ignored)


After this PR : 

> Without any placeholder, and with autoselectionFirst deactivated, the lib will keep default selected values