### PR TITLE
add new displayValueInBadge option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ Options can be either passed to the constructor (eg: optionName) or in data-opti
 | liveServer           | <code>Boolean</code>                                     | Should the endpoint be called each time on input                                                        |
 | noCache              | <code>Boolean</code>                                     | Prevent caching by appending a timestamp                                                                |
 | allowHtml            | <code>Boolean</code>                                     | Allow html in input (can lead to script injection)                                                      |
+| displayValueInBadge  | <bode>Boolean</code>                                     | Display the value attribute instead of text in badges. If no title is set, use the text as title.       |
 | inputFilter          | <code>function</code>                                    | Function to filter input                                                                                |
 | sanitizer            | <code>function</code>                                    | Alternative function to sanitize content                                                                |
 | debounceTime         | <code>Number</code>                                      | Debounce time for live server                                                                           |

--- a/tags.js
+++ b/tags.js
@@ -125,6 +125,7 @@
  * @property {Boolean} liveServer Should the endpoint be called each time on input
  * @property {Boolean} noCache Prevent caching by appending a timestamp
  * @property {Boolean} allowHtml Allow html in input (can lead to script injection)
+ * @property {Boolean} displayValueInBadge Display the value attribute instead of text in badges. If no title is set, use the text as title.
  * @property {Function} inputFilter Function to filter input
  * @property {Function} sanitizer Alternative function to sanitize content
  * @property {Number} debounceTime Debounce time for live server
@@ -210,6 +211,7 @@ const DEFAULTS = {
 	allowHtml: false,
 	debounceTime: 300,
 	notFoundMessage: "",
+	displayValueInBadge: false,
 	inputFilter: (str) => str,
 	sanitizer: (str) => sanitize(str),
 	onRenderItem: (item, label, inst) => {
@@ -2557,6 +2559,12 @@ class Tags {
 		const v5 = this._getBootstrapVersion() === 5;
 		const disabled = data.disabled && parseBool(data.disabled);
 		const allowClear = this._config.allowClear && !disabled;
+
+		if (this._config.displayValueInBadge) {
+			if (!data.title)
+				data.title = text;
+			text = value;
+		}
 
 		// create span
 		let html = this._config.allowHtml ? text : this._config.sanitizer(text);


### PR DESCRIPTION
The new option will display an option's value in the badge. If no explicit title is set, the text is used as title. The default retains current behaviour.

My use-case (a sort of issue tracker) has fairly long texts for items, but short IDs that are meaningful to users.
Displaying the complete text in the badge uses way too much horizontal space.